### PR TITLE
Compatibility with Django1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,11 @@ env:
   - TOXENV=py27-1.4
   - TOXENV=py27-1.5
   - TOXENV=py27-1.6
+  - TOXENV=py27-1.7
   - TOXENV=py33-1.5
   - TOXENV=py33-1.6
+  - TOXENV=py33-1.7
+  - TOXENV=py34-1.7
   - TOXENV=docs
 install:
   - pip install tox

--- a/ratelimitbackend/forms.py
+++ b/ratelimitbackend/forms.py
@@ -1,7 +1,12 @@
 from django import forms
-from django.contrib.admin.forms import (
-    AdminAuthenticationForm as AdminAuthForm, ERROR_MESSAGE,
-)
+from django.contrib.admin.forms import AdminAuthenticationForm as AdminAuthForm
+
+try:
+    from django.contrib.admin.forms import ERROR_MESSAGE
+except ImportError:
+    # The ERROR_MESSAGE has been moved in Django>=1.7
+    ERROR_MESSAGE = AdminAuthForm.error_messages['invalid_login']
+
 from django.contrib.auth import authenticate
 from django.contrib.auth.forms import AuthenticationForm as AuthForm
 from django.utils.translation import ugettext_lazy as _

--- a/ratelimitbackend/tests/__init__.py
+++ b/ratelimitbackend/tests/__init__.py
@@ -105,7 +105,8 @@ class RateLimitTests(TestCase):
 
     def test_ratelimit_admin_logins(self):
         url = reverse('admin:index')
-        response = self.client.get(url)
+        response = self.client.get(url, follow=True)
+        login_url = response.request['PATH_INFO']
         self.assertContains(response, 'username')
         wrong_data = {
             'username': u'hî',
@@ -113,10 +114,11 @@ class RateLimitTests(TestCase):
         }
         # 30 failing attempts are allowed
         for iteration in range(30):
-            response = self.client.post(url, wrong_data)
+            response = self.client.post(login_url, wrong_data)
             self.assertContains(response, 'username')
+            self.assertContains(response, 'for a staff account')
 
-        response = self.client.post(url, wrong_data)
+        response = self.client.post(login_url, wrong_data)
         self.assertRateLimited(response)
 
     def test_django_registry(self):
@@ -130,7 +132,7 @@ class RateLimitTests(TestCase):
             self.assertEqual(len(w), 1)
         url = reverse('admin:index')
         response = self.client.get(url)
-        self.assertContains(response, 'in the Auth application')
+        self.assertContains(response, 'in the Auth')
         self.assertContains(response, '"/admin/auth/user/add/"')
 
     def test_custom_ratelimit_logic(self):

--- a/runtests.py
+++ b/runtests.py
@@ -75,6 +75,11 @@ def setup_test_environment():
 
     # set up settings for running tests for all apps
     settings.configure(**settings_dict)
+    try:
+        from django import setup
+        setup()  # Needed for Django>=1.7
+    except ImportError:
+        pass
 
 
 def runtests(*test_args):

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,9 @@
 envlist =
 	py26-1.4, py26-1.5, py26-1.6,
 	py27-1.4, py27-1.5, py27-1.6,
-	py33-1.5, py33-1.6,
+	py27-1.7,
+	py33-1.5, py33-1.6, py33-1.7,
+	py34-1.7,
 	docs
 
 [testenv]
@@ -45,6 +47,11 @@ basepython = python2.7
 deps =
     Django<1.7
 
+[testenv:py27-1.7]
+basepython = python2.7
+deps =
+    https://www.djangoproject.com/download/1.7c1/tarball/
+
 [testenv:py33-1.5]
 basepython = python3.3
 deps =
@@ -54,3 +61,13 @@ deps =
 basepython = python3.3
 deps =
     Django<1.7
+
+[testenv:py33-1.7]
+basepython = python3.3
+deps =
+    https://www.djangoproject.com/download/1.7c1/tarball/
+
+[testenv:py34-1.7]
+basepython = python3.4
+deps =
+    https://www.djangoproject.com/download/1.7c1/tarball/


### PR DESCRIPTION
Several modifications in the Django1.7rc1 impact the usage of this lib:
- admin login redirection strategy: https://docs.djangoproject.com/en/dev/releases/1.7/#admin-login-redirection-strategy
- app-loading: https://docs.djangoproject.com/en/dev/releases/1.7/#standalone-scripts

This last point might need some clarification in the docs: in the Django docs,
it says that now `django.contrib.admin` autodiscovers automatically, and thus
the `admin.autodiscover` is now useless.
In fact, this is because it ships with an `AppConfig` that runs the
autodiscovery when the app-loading is done.
Unless you plan to have the same functionality in this lib, we still need an
explicit `autodiscover`.

Source: https://docs.djangoproject.com/en/dev/releases/1.7/#app-loading-refactor
