### PR TITLE
Add "sensitive_post_parameters" decorator to login view

### DIFF
--- a/ratelimitbackend/views.py
+++ b/ratelimitbackend/views.py
@@ -10,10 +10,12 @@ from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_protect
+from django.views.decorators.debug import sensitive_post_parameters
 
 from .forms import AuthenticationForm
 
 
+@sensitive_post_parameters()
 @csrf_protect
 @never_cache
 def login(request, template_name='registration/login.html',


### PR DESCRIPTION
Django's own login view has had this since 1.4

See Django docs: https://docs.djangoproject.com/en/1.4/howto/error-reporting/#django.views.decorators.debug.sensitive_post_parameters
