### PR TITLE
Avoid nuking REDIRECT_FIELD_NAME

### DIFF
--- a/ratelimitbackend/admin.py
+++ b/ratelimitbackend/admin.py
@@ -16,8 +16,10 @@ class RateLimitAdminSite(AdminSite):
         context = {
             'title': _('Log in'),
             'app_path': request.get_full_path(),
-            REDIRECT_FIELD_NAME: request.get_full_path(),
         }
+        if (REDIRECT_FIELD_NAME not in request.GET and
+                REDIRECT_FIELD_NAME not in request.POST):
+            context[REDIRECT_FIELD_NAME] = request.get_full_path()
         context.update(extra_context or {})
         defaults = {
             'extra_context': context,


### PR DESCRIPTION
Taking a lead from
https://github.com/django/django/blob/master/django/contrib/admin/sites.py#L384
it now only sets the redirect field to the value of
request.get_full_path() if the field does not already have a value.