### PR TITLE
Test against Django 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: 3.4
+python: 3.5
 sudo: false
 env:
   - TOXENV=py26-django14
@@ -10,6 +10,7 @@ env:
   - TOXENV=py27-django16
   - TOXENV=py27-django17
   - TOXENV=py27-django18
+  - TOXENV=py27-django19
   - TOXENV=py33-django15
   - TOXENV=py33-django16
   - TOXENV=py33-django17
@@ -18,6 +19,8 @@ env:
   - TOXENV=py34-django16
   - TOXENV=py34-django17
   - TOXENV=py34-django18
+  - TOXENV=py34-django19
+  - TOXENV=py35-django19
   - TOXENV=docs
   - TOXENV=lint
 install:

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ],
     test_suite='runtests.runtests',
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,15 @@
 # Matrix looks like:
 #
 # py26-1.4, py26-1.5, py26-1.6,
-# py27-1.4, py27-1.5, py27-1.6, py27-1.7, py27-1.8,
+# py27-1.4, py27-1.5, py27-1.6, py27-1.7, py27-1.8, py27-1.9,
 #           py33-1.5, py33-1.6, py33-1.7, py33-1.8,
-#           py34-1.5, py34-1.6, py34-1.7, py34-1.8,
+#           py34-1.5, py34-1.6, py34-1.7, py34-1.8, py34-1.9,
+#                                                   py35-1.9,
 envlist =
 	py2{6,7}-django14,
 	py26-django1{5,6},
 	py{27,33,34}-django1{5,6,7,8},
+	py{27,34,35}-django19,
 	docs, lint
 
 [testenv]
@@ -19,6 +21,7 @@ deps =
 	django16: Django>=1.6,<1.7
 	django17: Django>=1.7,<1.8
 	django18: Django>=1.8,<1.9
+	django19: Django>=1.9,<1.10
 	django14,django15: django-discover-runner
 install_command = pip install --no-binary Django {opts} {packages}
 


### PR DESCRIPTION
For completeness

1.9 drops support for Python 3.3 and adds support for 3.5