### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ customized.
 
 * Compatibility: Django 1.4 and greater
 
-* Documentation: http://django-ratelimit-backend.rtfd.org
+* Documentation: https://django-ratelimit-backend.readthedocs.io
 
 * Code: https://github.com/brutasse/django-ratelimit-backend
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.