### PR TITLE
Remove obsolete installcommand in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ commands = python -Wall setup.py test
 deps =
 	django18: Django>=1.8,<1.9
 	django19: Django>=1.9,<1.10
-install_command = pip install --no-binary Django {opts} {packages}
 
 [testenv:docs]
 changedir = docs


### PR DESCRIPTION
This was needed for Django 1.4 support.