### PR TITLE
Allow calling without username argument

### DIFF
--- a/ratelimitbackend/backends.py
+++ b/ratelimitbackend/backends.py
@@ -21,7 +21,7 @@ class RateLimitMixin(object):
     username_key = 'username'
 
     def authenticate(self, request=None, **kwargs):
-        username = kwargs[self.username_key]
+        username = kwargs.get(self.username_key)
         if request is not None:
             counts = self.get_counters(request)
             if sum(counts.values()) >= self.requests:


### PR DESCRIPTION
Fixes https://github.com/brutasse/django-ratelimit-backend/issues/31

Unfortunately this breaks a test and I'm not sure what to do about that:

```
FAIL: test_custom_backend_no_username_key (tests.test_backends.RateLimitTests)
Custom backend with missing username_key
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/mnt/nfshome/plotly/django-ratelimit-backend/.tox/py27-django18/local/lr
    return test_func(*args, **kwargs)
  File "/mnt/nfshome/plotly/django-ratelimit-backend/tests/test_backends.py", ly
    self.assertRaises(KeyError, self.client.post, url, wrong_data)
AssertionError: KeyError not raised
```

I see that this is testing that a broken backend that does not define a `username_key` but does not use `username` results in an error. Unfortunately for the case of OAuth 2 bearer tokens, there's nothing analogous to a username. There's just a token, which takes the place of both a username and password, and tokens should not be logged on failure.

@brutasse @treyhunner Do you have any suggestions on what to do about this?

The test that's failing was added back in https://github.com/brutasse/django-ratelimit-backend/pull/7 .  How important is it to detect a missing `username_key`? If someone leaves this out by accident I think it's likely that they'll notice when they check their logs and see `None` where they were expecting an email address or whatever. But I'm open to other suggestions!