### PR TITLE
CI test commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,5 @@ addons:
     sources:
       - deadsnakes
     packages:
+      - python3.3
       - python3.5  # https://github.com/travis-ci/travis-ci/issues/4794


### PR DESCRIPTION
CI is failing on my branch with:
`ERROR: InterpreterNotFound: python3.3`

I'm making this commit to run CI on master to see if it fails with the same error (master has not had a CI run in 6 months so it's possible something external has changed).