### PR TITLE
Update docs for correct MIDDLEWARE setting name.

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -44,8 +44,8 @@ Quickstart
   rate-limiting. You can keep registering your models to the default admin
   site and they will show up in the ratelimitbackend-enabled admin.
 
-* Add ``'ratelimitbackend.middleware.RateLimitMiddleware'`` to your
-  ``MIDDLEWARE_CLASSES``, or create you own middleware to handle rate limits.
+* Add ``'ratelimitbackend.middleware.RateLimitMiddleware'`` to ``MIDDLEWARE``
+  in your settings, or create you own middleware to handle rate limits.
   See the :ref:`middleware reference <middleware>`.
 
 * If you use ``django.contrib.auth.forms.AuthenticationForm`` directly,


### PR DESCRIPTION
In [Django 1.10 release notes](https://docs.djangoproject.com/en/2.0/releases/1.10/):

> A new style of middleware is introduced to solve the lack of strict request/response layering of the old-style of middleware described in DEP 0005. You’ll need to adapt old, custom middleware and switch from the MIDDLEWARE_CLASSES setting to the new MIDDLEWARE setting to take advantage of the improvements.