### PR TITLE
Update test matrix with modern versions of Django

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,17 @@
 language: python
-python: 3.6
+python:
+  - 3.5
+  - 3.6
+  - 3.7
+  - 3.8
 sudo: false
-env:
-  - TOXENV=py27-django111
-  - TOXENV=py34-django111
-  - TOXENV=py35-django111
-  - TOXENV=py36-django111
-  - TOXENV=py34-django20
-  - TOXENV=py35-django20
-  - TOXENV=py36-django20
-  - TOXENV=py35-django21
-  - TOXENV=py36-django21
-  - TOXENV=docs
-  - TOXENV=lint
-install:
-  - pip install tox
-script:
-  - tox -e $TOXENV
-addons:
-  apt:
-    sources:
-      - deadsnakes
-    packages:
-      - python3.5  # https://github.com/travis-ci/travis-ci/issues/4794
+install: pip install tox-travis
+script: tox
+matrix:
+  include:
+    - python: 3.6
+      env: TOX_ENV=lint
+      script: tox -e $TOX_ENV
+    - python: 3.6
+      env: TOX_ENV=docs
+      script: tox -e $TOX_ENV

--- a/ratelimitbackend/admin.py
+++ b/ratelimitbackend/admin.py
@@ -3,7 +3,7 @@
 from django.contrib.admin import *  # noqa
 from django.contrib.admin import site as django_site
 from django.contrib.auth import REDIRECT_FIELD_NAME
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from .forms import AdminAuthenticationForm
 from .views import login

--- a/ratelimitbackend/forms.py
+++ b/ratelimitbackend/forms.py
@@ -3,7 +3,7 @@ from django.contrib.admin.forms import AdminAuthenticationForm as AdminAuthForm
 
 from django.contrib.auth import authenticate
 from django.contrib.auth.forms import AuthenticationForm as AuthForm
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class AuthenticationForm(AuthForm):

--- a/ratelimitbackend/views.py
+++ b/ratelimitbackend/views.py
@@ -1,9 +1,10 @@
+from urllib.parse import urlparse
+
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME, login as auth_login
 from django.contrib.sites.shortcuts import get_current_site
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
-from django.utils.six.moves.urllib.parse import urlparse
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.debug import sensitive_post_parameters

--- a/runtests.py
+++ b/runtests.py
@@ -68,6 +68,7 @@ def setup_test_environment():
                 ),
                 'context_processors': (
                     'django.contrib.auth.context_processors.auth',
+                    'django.contrib.messages.context_processors.messages',
                 ),
             },
         }],

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-ignore = F405
+ignore = F405 W504
 
 [wheel]
 universal = 1

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,18 @@
 [tox]
 envlist =
-	py{27,34,35,36}-django111,
-	py{34,35,36}-django20,
-	py{35,36}-django21,
+	py{35,36,37}-django111,
+	py{35,36,37,38}-django21,
+	py{35,36,37,38}-django22,
+	py{36,37,38}-django30,
 	docs, lint
 
 [testenv]
 commands = python -Wall setup.py test
 deps =
 	django111: Django>=1.11a1,<2.0
-	django20: Django>=2.0a1,<2.1
 	django21: Django>=2.1,<2.2
+	django22: Django>=2.2,<2.3
+	django30: Django>=3.0,<3.1
 
 [testenv:docs]
 changedir = docs


### PR DESCRIPTION
* Add new versions of Django to test matrix
* Add tox-travis to run appropriate environments automagically
* Removed Python 2.7 and3.4 from test matrix  as they are EOL
* Remove imports from modules that don't exist anymore
* Generally fix stuff Django 3.0 complained about.