### PR TITLE
Instantiate RateLimitAdminSite in apps.py

### DIFF
--- a/ratelimitbackend/__init__.py
+++ b/ratelimitbackend/__init__.py
@@ -1,1 +1,3 @@
-__version__ = '2.0'
+__version__ = '2.0.1'
+
+default_app_config = 'ratelimitbackend.apps.DjangoRatelimitBackendConfig'

--- a/ratelimitbackend/admin.py
+++ b/ratelimitbackend/admin.py
@@ -1,37 +1,5 @@
 # Allow transitive imports, e.g.
 # `from ratelimitbackend import admin; admin.ModelAdmin`
 from django.contrib.admin import *  # noqa
-from django.contrib.admin import site as django_site
-from django.contrib.auth import REDIRECT_FIELD_NAME
-from django.utils.translation import ugettext as _
 
-from .forms import AdminAuthenticationForm
-from .views import login
-
-
-class RateLimitAdminSite(AdminSite):  # noqa
-    def login(self, request, extra_context=None):
-        """
-        Displays the login form for the given HttpRequest.
-        """
-        context = {
-            'title': _('Log in'),
-            'app_path': request.get_full_path(),
-        }
-        if (REDIRECT_FIELD_NAME not in request.GET and
-                REDIRECT_FIELD_NAME not in request.POST):
-            context[REDIRECT_FIELD_NAME] = request.get_full_path()
-        context.update(extra_context or {})
-        defaults = {
-            'extra_context': context,
-            'current_app': self.name,
-            'authentication_form': self.login_form or AdminAuthenticationForm,
-            'template_name': self.login_template or 'admin/login.html',
-        }
-        return login(request, **defaults)
-
-
-site = RateLimitAdminSite()
-
-for model, admin in django_site._registry.items():
-    site.register(model, admin.__class__)
+from .apps import site

--- a/ratelimitbackend/apps.py
+++ b/ratelimitbackend/apps.py
@@ -1,0 +1,39 @@
+from django.contrib.admin import AdminSite
+from django.apps.config import AppConfig
+from django.utils.translation import ugettext as _
+
+class DjangoRatelimitBackendConfig(AppConfig):
+    name = 'ratelimitbackend'
+
+    def ready(self):
+        from django.contrib.admin import site as django_site
+        for model, admin in django_site._registry.items():
+            site.register(model, admin.__class__)
+
+
+class RateLimitAdminSite(AdminSite):  # noqa
+    def login(self, request, extra_context=None):
+        """
+        Displays the login form for the given HttpRequest.
+        """
+        from .forms import AdminAuthenticationForm
+        from .views import login
+        from django.contrib.auth import REDIRECT_FIELD_NAME
+        context = {
+            'title': _('Log in'),
+            'app_path': request.get_full_path(),
+        }
+        if (REDIRECT_FIELD_NAME not in request.GET and
+                REDIRECT_FIELD_NAME not in request.POST):
+            context[REDIRECT_FIELD_NAME] = request.get_full_path()
+        context.update(extra_context or {})
+        defaults = {
+            'extra_context': context,
+            'current_app': self.name,
+            'authentication_form': self.login_form or AdminAuthenticationForm,
+            'template_name': self.login_template or 'admin/login.html',
+        }
+        return login(request, **defaults)
+
+
+site = RateLimitAdminSite()


### PR DESCRIPTION
We have seen increasing cases of the bug described in https://stackoverflow.com/questions/62536538/django-runserver-failing-during-admin-site-checks when running the https://github.com/edx/edx-platform development environment. This applies the recommended fix to see if that resolves our issues.